### PR TITLE
Update IT140 command to remove unnecessary work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 test_cmd.py
 pip-selfcheck.json
 *.yml
+*.html
+*.sh

--- a/cmds/it140.py
+++ b/cmds/it140.py
@@ -94,13 +94,11 @@ def execute(command, user):
     if len(cmd) > 1:
         topic = cmd[1].lower()
         try:
-            if topic == "help":
-                response = "Here is a list of valid IT-140 topics:\n\n" + "\n".join("- `{}`".format(x) for x in data.keys() if x != "it140")
-            else:
-                attachment = build_attachment(topic)
+            attachment = build_attachment(topic)
         except KeyError:
-            response = "I'm sorry, Dave.  I'm afraid I can't do that. Try `<@{}> it140 help` for a list of topics.".format(bot_id)
+            response = "I'm sorry, Dave.  I'm afraid I can't do that. Try `<@{}> it140` for a list of valid topics.".format(bot_id)
     else:
-        response = "Looks like you may have forgotten the topic.  You can get a list from `<@{}> it140 help`.".format(bot_id)
+        response = "Here is a list of valid IT-140 topics.  Proceed by entering: `<@{}> it140 topic`. \n\n".format(bot_id) \
+            + "\n".join("- `{}`".format(x) for x in data.keys() if x != "it140")
              
     return response, attachment

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,8 +49,8 @@ Noob SNHUbot will respond to the following direct messages. To begin a conversat
 * it140
   * Gives links to tutorial videos pertaining to course material in IT-140.
   * Requires secondary command to indicate desired topic: `@Noob SNHUbot it140 topic`.
+    * Calling the command with no topic, `@Noob SNHUbot it140 topic`, gives a help list with valid topics.
   * Valid secondary commands are:
-    * `help`: gives a list of valid commands.
     * `basics`: gives video links pertaining to Python basics.
     * `dicts`: gives video links pertaining to Python dictionaries.
     * `files`: gives video links pertaining to Python file handling.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ Noob SNHUbot will respond to the following direct messages. To begin a conversat
 * it140
   * Gives links to tutorial videos pertaining to course material in IT-140.
   * Requires secondary command to indicate desired topic: `@Noob SNHUbot it140 topic`.
-    * Calling the command with no topic, `@Noob SNHUbot it140 topic`, gives a help list with valid topics.
+    * Calling the command with no topic, `@Noob SNHUbot it140`, gives a help list with valid topics.
   * Valid secondary commands are:
     * `basics`: gives video links pertaining to Python basics.
     * `dicts`: gives video links pertaining to Python dictionaries.


### PR DESCRIPTION
Since the command's inception, it's become obvious that `help` functionality is largely unnecessary.  It would typically confuse people and require more work.  Adjustments have been made so that using the command with no topic gives a list of valid commands:

![New Default](https://user-images.githubusercontent.com/29785667/57573457-94535780-73dc-11e9-8d81-098ba6700bf1.jpg)

One less step, and hopefully less confusing.