### PR TITLE
Feature book requests

### DIFF
--- a/cmds/packtbook.py
+++ b/cmds/packtbook.py
@@ -133,7 +133,7 @@ def insert_user_into_request(requests: dict, word: str, insert_user: str):
     mongo.update_document_by_oid(requests["_id"], {"$push": {word: insert_user}})
 
 
-def remove_user_from_words(requests: dict, words: list, user: str):
+def remove_user_from_words(requests: dict, words: list, remove_user: str):
     """
     Removes the user from a single word in the collection of requests.  Also
     calls remove_request_word if the user was the sole user in the request.
@@ -142,8 +142,8 @@ def remove_user_from_words(requests: dict, words: list, user: str):
     :type requests: dict
     :param words: list of words from which to remove the user
     :type words: list
-    :param user: user to be removed from the request words
-    :type user: str
+    :param remove_user: user to be removed from the request words
+    :type remove_user: str
     :return: None
     :rtype: None
     """
@@ -151,7 +151,7 @@ def remove_user_from_words(requests: dict, words: list, user: str):
     # Process each of the words given
     for word in words:
         # Remove the user's association with the request word
-        requests[word].remove(user)
+        requests[word].remove(remove_user)
         mongo.update_document_by_oid(requests["_id"], {"$set": {word: requests[word]}})
 
         # Then check to see if the word's list is empty.  If so, remove it from the

--- a/cmds/packtbook.py
+++ b/cmds/packtbook.py
@@ -6,15 +6,36 @@ from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.chrome.options import Options
 from urllib.error import HTTPError
+from noob_snhubot import DB_CONFIG
 
 command = 'packtbook'
 public = True
+do_requests = True
 opts = Options()
 opts.add_argument("--headless")
 opts.add_argument('--no-sandbox')
 opts.add_argument('--disable-dev-shm-usage')
 driver = webdriver.Chrome(chrome_options=opts)
 increment = 0.5
+
+# Check to see if we're using a Mongo configuration.  If so,
+# set the db and collection.  If not, disable the requests
+# functionality
+if DB_CONFIG:
+    # Grab the main mongo connection
+    from noob_snhubot import mongo
+
+    # Be sure we're using the right db
+    mongo.use_collection(DB_CONFIG["db"])
+
+    # Secondary check to see if a collection has been set.  If not
+    # disable the requests
+    if "book_requests" in DB_CONFIG["collections"]:
+        mongo.use_collection(DB_CONFIG["collections"]["book_requests"])
+    else:
+        do_requests = False
+else:
+    do_requests = False
 
 
 def grab_element(delay, elem_function, attr):
@@ -45,71 +66,144 @@ def execute(command, user):
     time_attrs = ["hours", "minutes", "seconds"]
     url = 'https://www.packtpub.com/packt/offers/free-learning/'
 
-    # Simple catch all error logic
-    try:
-        # Set the driver to wait a little bit before assuming elements are not present, then grab the page:
-        driver.implicitly_wait(delay)
-        driver.get(url)
+    # Split the given command here and set it all to lowercase
+    split_command = [x.lower() for x in command.split(" ")] if len(command.split(" ")) > 1 else None
 
-        # Get the elements
-        warning_message = grab_element(2, driver.find_element_by_css_selector, ".message.warning")
-        book_string = grab_element(delay, driver.find_element_by_class_name, "product__title")
-        img_src = grab_element(delay, driver.find_element_by_class_name, "product__img")
-        time_string = grab_element(delay, driver.find_element_by_class_name, "countdown__timer")
+    # Check to see if the user is trying a request.  If so, insert them
+    # into the collection.  If not, proceed as normal
+    if split_command and split_command[1] == "request":
+        # If requests are enabled, then do the work.  If not, tell the user that requests are disabled.
+        if do_requests:
+            # See if there is a doc in the collection.  If not, insert a blank one
+            if mongo.count_documents({}) == 0:
+                mongo.insert_document({})
+                requests = mongo.find_document({})
+            else:
+                requests = mongo.find_document({})
 
-        # Check to see if the warning message was present
-        if warning_message:
-            response = warning_message
-        # If any of the regular elements fail, tell the people to try again.  If not, do the attachment
-        elif None in [book_string, img_src, time_string]:
-            response = "This operation has failed.  Dynamic page elements are weird like that.  Try again."
+            if len(split_command) > 2:
+                if split_command[2] == "--delete":
+                    # Gather the words, making sure there are no blanks
+                    words = [x.replace(",", "") for x in split_command[3:] if len(x.replace(",", "")) > 0]
+
+                    # For each word given, remove the user from the word's entry in the collection
+                    if len(words) > 0:
+                        for word in words:
+                            if word in requests:
+                                requests[word].remove(user)
+                                mongo.update_document_by_oid(requests["_id"], {"$set": {word: requests[word]}})
+
+                        response = "I have removed your request(s) for: " + ", ".join(words)
+                    else:
+                        # If the words list is empty, then the user didn't provide any words
+                        response = "The correct format for deleting requests is the following:\n\n" \
+                            "`@NoobSNHUbot packtbook request --delete words, to, delete, here`"
+                elif split_command[2] == "--clear":
+                    # For each word in the collection, remove the user from the list
+                    for word in [x for x in requests.keys() if x != "_id"]:
+                        if user in requests[word]:
+                            requests[word].remove(user)
+                            mongo.update_document_by_oid(requests["_id"], {"$set": {word: requests[word]}})
+
+                    response = "All of your requests have been cleared."
+                elif split_command[2] == "--justforfun":
+                    request_list = []
+
+                    # Here we are simply iterating through the collection to build a nice
+                    # list to print
+                    for word in [x for x in requests.keys() if x != "_id"]:
+                        request_list.append(f"{word}: {' '.join(requests[word])}")
+
+                    response = "Here are the current requests:\n\n" + "\n".join(f"`{word}`" for word in request_list)
+                else:
+                    # Gather the words, making sure there are no blanks
+                    words = [x.replace(",", "") for x in split_command[2:] if len(x.replace(",", "")) > 0]
+
+                    # See if the words are already in the collection.  If they are, add the user to them if they aren't
+                    # there already.  If the words are not there, add them with an initial list of a single user.
+                    for word in words:
+                        if word in requests:
+                            # Only add the user if they are not in there
+                            if user not in requests[word]:
+                                mongo.update_document_by_oid(requests["_id"], {"$push": {word: user}})
+                        else:
+                            mongo.update_document_by_oid(requests["_id"], {"$set": {word: [user]}})
+
+                    response = "You have made a book request for: " + ", ".join(words)
+            else:
+                response = "The correct format is the following:\n\n" \
+                    "To add: `@NoobSNHUbot packtbook request words, to, add, here`\n" \
+                    "To delete: `@NoobSNHUbot packtbook request --delete words, to, delete, here`\n" \
+                    "To clear all: `@NoobSNHUbot packtbook request --clear`"
+
         else:
-            # Set the time here
-            time_split = [int(x) for x in time_string.split(":")]
-            times_left = []
+            response = "Requests are currently disabled.  Contact your workspace admin for information."
+    else:
+        # Simple catch all error logic
+        try:
+            # Set the driver to wait a little bit before assuming elements are not present, then grab the page:
+            driver.implicitly_wait(delay)
+            driver.get(url)
 
-            for t in time_split:
-                ind = time_split.index(t)
-                if t == 0:
-                    # If there are no hours/etc, go ahead and skip it
-                    pass
-                elif t == 1:
-                    times_left.append("{} {}".format(t, time_attrs[ind][:-1]))
-                elif t > 1:
-                    times_left.append("{} {}".format(t, time_attrs[ind]))
+            # Get the elements
+            warning_message = grab_element(2, driver.find_element_by_css_selector, ".message.warning")
+            book_string = grab_element(delay, driver.find_element_by_class_name, "product__title")
+            img_src = grab_element(delay, driver.find_element_by_class_name, "product__img")
+            time_string = grab_element(delay, driver.find_element_by_class_name, "countdown__timer")
 
-            time_format = "{}"
+            # Check to see if the warning message was present
+            if warning_message:
+                response = warning_message
+            # If any of the regular elements fail, tell the people to try again.  If not, do the attachment
+            elif None in [book_string, img_src, time_string]:
+                response = "This operation has failed.  Dynamic page elements are weird like that.  Try again."
+            else:
+                # Set the time here
+                time_split = [int(x) for x in time_string.split(":")]
+                times_left = []
 
-            if len(times_left) == 2:
-                time_format = "{} and {}"
-            elif len(times_left) == 3:
-                time_format = "{}, {}, and {}"
+                for t in time_split:
+                    ind = time_split.index(t)
+                    if t == 0:
+                        # If there are no hours/etc, go ahead and skip it
+                        pass
+                    elif t == 1:
+                        times_left.append("{} {}".format(t, time_attrs[ind][:-1]))
+                    elif t > 1:
+                        times_left.append("{} {}".format(t, time_attrs[ind]))
 
-            time_left_string = time_format.format(*times_left)
+                time_format = "{}"
 
-            output = {
-                "pretext": "The Packt Free Book of the Day is:",
-                "title": book_string,
-                "title_link": url,
-                "footer": "There's still {} to get this book!".format(time_left_string),
-                "color": "#ffca5b",
-                "image_url": "{}".format(img_src)
-            }
+                if len(times_left) == 2:
+                    time_format = "{} and {}"
+                elif len(times_left) == 3:
+                    time_format = "{}, {}, and {}"
 
-            attachment = json.dumps([output])
+                time_left_string = time_format.format(*times_left)
 
-    except HTTPError as err:
-        print(err)
+                output = {
+                    "pretext": "The Packt Free Book of the Day is:",
+                    "title": book_string,
+                    "title_link": url,
+                    "footer": "There's still {} to get this book!".format(time_left_string),
+                    "color": "#ffca5b",
+                    "image_url": "{}".format(img_src)
+                }
 
-        response = "It appears that the free book page doesn't exist anymore.  Are they still giving away books?"
-    except (TimeoutError, TimeoutException) as err:
-        print(err)
+                attachment = json.dumps([output])
 
-        response = "Looks like the operation timed out.  Please try again later."
-    except Exception as err:
-        print(err)
+        except HTTPError as err:
+            print(err)
 
-        response = 'I have failed my human overlords!\nYou should be able to find the Packt Free' \
-                   ' Book of the day here: {}'.format(url)
+            response = "It appears that the free book page doesn't exist anymore.  Are they still giving away books?"
+        except (TimeoutError, TimeoutException) as err:
+            print(err)
+
+            response = "Looks like the operation timed out.  Please try again later."
+        except Exception as err:
+            print(err)
+
+            response = 'I have failed my human overlords!\nYou should be able to find the Packt Free' \
+                       ' Book of the day here: {}'.format(url)
 
     return response, attachment

--- a/cmds/packtbook.py
+++ b/cmds/packtbook.py
@@ -100,8 +100,7 @@ def insert_request_word(requests: dict, word: str, first_user: str):
 
 def remove_request_word(requests: dict, word: str):
     """
-    Iterates the current collection of request entries, removing those
-    that no longer have requests.
+    Removes the given word from the collection of requests
 
     :param requests: current collection of requests
     :type requests: dict

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,13 @@ Noob SNHUbot will respond to the following direct messages. To begin a conversat
     * `regex`: gives video links pertaining to regular expressions in Python. 
 * packtbook
   * Reaches out to the Packtbook Website to display the latest free book of the day.
-  * `packtbook mini` will show the attachment in a smaller format.
+  * Accepts sub-command `request`:
+    * Calling `packbook request` allows a user to register keywords with the bot such that they get tagged if a book matching their keywords is posted in the channel.
+    * `packtbook request [list, of, words, here]` registers request words for a user. Words can be separated by either a space or a comma.
+    * `packtbook request --delete [list, of, words, here]` removes words from a user's requests.  Again, words can be separated by either a space or a comma.
+    * `packtbook request --clear` removes every request for the user running the command.
+    * `packtbook request --justforfun` simply prints out a mostly incomprehensible list of the current requests.
+    * Admin functionality may be added at a later date.
   * Automatically scheduled to launch at 8:30PM Eastern Time.
 * roll `XdY[±Z]`
   * Rolls X number of Y-Sided dice with a + or - Z modifier!
@@ -116,11 +122,12 @@ mongo:
   collections:
     conn: conn_log
     cmds: cmd_log
+    book_requests: book_req
   hostname: my_db_server
   port: 27017
 ```
 
-Mongo DB logging is optional and can be omitted from the configuration file.
+Mongo DB logging is optional and can be omitted from the configuration file.  Also, `book_requests` can be omitted specifically to only disable book requests with the `packtbook` command.
 
 Additionally, the `config.yml` file can be omitted to fall back on utilizing the `SLACK_CLIENT` environment variable.
 


### PR DESCRIPTION
This is, finally, the introduction of book requests!

I think it's at the point of needing another set of eyes.  Here is where we are:

* The functionality is disabled if: there is no existing DB config, or if there is no `book_requests` entry in the config
* The bulk of the work takes place when the user enters `packtbook request`.  If they provide a list of words, this list is then added to a Mongo collection containing a single document of words.  The choice to keep it as a single document seemed like it would keep searching as simple as possible.  Anyway, each word gets its own field in the document, which is then given a list of user IDs.
* Requests can then be deleted with `packtbook request --delete`.  The user can give a single word or a list.  For each word that's there, the user's ID is then removed from the field in the collection.  If a word ends up with zero user IDs, it gets removed.
* A user can remove all of their requests at once with `packtbook request --clear`.  Again, if a word ends up empty, it gets removed.
* There is also `packtbook request --justforfun`, which just prints out the current requests and user IDs.  Mostly useless since I am not translating the names, but it's there.
* It will probably be handy later to have some sort of admin command like `packtbook request --clear [user]`, but who knows.
* `re` substitution is used in lieu of the regular `str` one for the sake of future proofing.  It's hard to know what sort of weirdness might crop up in book titles down the line.
* I have put the obvious things into their own functions, but nothing else is currently standing out.  The logic seems to be as good as it's going to get without repeating end points.
* Also, I updated the README.