### PR TITLE
Packtbook view-your-own requests and hefty refactor update

### DIFF
--- a/cmds/packtbook.py
+++ b/cmds/packtbook.py
@@ -1,3 +1,12 @@
+"""Packtbook command module
+
+Todo:
+    * Even though this has been refactored, things can still tighten up a bit.
+    * Typing hints are not complete
+    * Admin features at some point
+    * Explore requests-html as an alternative to selenium
+"""
+
 import json
 import time
 import re
@@ -6,11 +15,11 @@ from selenium import webdriver
 from selenium.common.exceptions import TimeoutException, NoSuchElementException, WebDriverException
 from selenium.webdriver.chrome.options import Options
 from urllib.error import HTTPError
+from typing import Any
 
 command = 'packtbook'
 public = True
 increment = 0.5
-
 
 # The following regex is designed to separate all of the words given
 # for requests while accounting for phrases indicated by "phrase".
@@ -29,6 +38,33 @@ try:
 except WebDriverException as e:
     print("Error encountered while starting the ChromeDriver:\n{}".format(e))
     driver = None
+
+
+def parse_arguments(command) -> (str, set):
+    split_command = [x.lower() for x in separator_regex.findall(command)]
+
+    if len(split_command) == 1:
+        return "packtbook", None
+    elif len(split_command) > 2 and split_command[1] in ["request", "requests"] \
+            and split_command[2] in ["-a", "--add"]:
+        return "request_add", {x for x in split_command[3:] if not x.startswith("-")}
+    elif len(split_command) > 2 and split_command[1] in ["request", "requests"] \
+            and split_command[2] in ["-d", "--delete"]:
+        return "request_delete", {x for x in split_command[3:] if not x.startswith("-")}
+    elif len(split_command) == 3 and split_command[1] in ["request", "requests"] \
+            and split_command[2] in ["-l", "--list"]:
+        return "request_list", None
+    elif len(split_command) == 3 and split_command[1] in ["request", "requests"] \
+            and split_command[2] in ["-c", "--clear"]:
+        return "request_clear", None
+    elif len(split_command) == 3 and split_command[1] in ["request", "requests"] \
+            and split_command[2] == "--admin":
+        return "request_admin", None
+    elif len(split_command) == 3 and split_command[1] in ["request", "requests"] \
+            and split_command[2] == "--dump":
+        return "request_dump", None
+    else:
+        return "packtbook_help", None
 
 
 def grab_element(delay, elem_function, attr):
@@ -52,182 +88,157 @@ def grab_element(delay, elem_function, attr):
         delay -= increment
 
 
+def request_add(words: set, user: str, bot: Any) -> str:
+    if len(words) > 0:
+        # See if the words are already in the collection.  If they are, add the user to them if they aren't
+        # there already.  If the words are not there, add them with an initial list of a single user.
+        for word in words:
+            req = bot.db_conn.find_document(
+                {"word": word},
+                db=bot.db_conn.CONFIG["db"],
+                collection=bot.db_conn.CONFIG["collections"]["book_requests"],
+            )
+
+            if req:
+                # Only add the user if they are not in there
+                if user not in req["users"]:
+                    # Insert the user into the word
+                    req["users"].append(user)
+                    # Then update the document in the db
+                    bot.db_conn.update_document_by_oid(
+                        req["_id"],
+                        {"$set": {"users": req["users"]}},
+                        db=bot.db_conn.CONFIG["db"],
+                        collection=bot.db_conn.CONFIG["collections"]["book_requests"]
+                    )
+            else:
+                bot.db_conn.insert_document(
+                    {"word": word, "users": [user]},
+                    db=bot.db_conn.CONFIG["db"],
+                    collection=bot.db_conn.CONFIG["collections"]["book_requests"],
+                )
+        return "You have made a book request for: " + ", ".join(words)
+    else:
+        return "You didn't list any valid words to add!"
+
+
+def request_delete(words: set, user: str, bot: Any) -> str:
+    # For each word given, remove the user from the word's entry in the collection
+    if len(words) > 0:
+        req = bot.db_conn.find_documents(
+            {"word": {"$in": list(words)}},
+            db=bot.db_conn.CONFIG["db"],
+            collection=bot.db_conn.CONFIG["collections"]["book_requests"],
+        )
+
+        for word in req:
+            if user in word["users"]:
+                word["users"].remove(user)
+
+                # Then check to see if the word's list is empty.  If so, remove it from the
+                # collection
+                if len(word["users"]) == 0:
+                    bot.db_conn.delete_document(
+                        {"word": word["word"]},
+                        db=bot.db_conn.CONFIG["db"],
+                        collection=bot.db_conn.CONFIG["collections"]["book_requests"]
+                    )
+                else:
+                    bot.db_conn.update_document_by_oid(
+                        word["_id"],
+                        {"$set": {"users": word["users"]}},
+                        db=bot.db_conn.CONFIG["db"],
+                        collection=bot.db_conn.CONFIG["collections"]["book_requests"]
+                    )
+
+        return "I have deleted your request(s) for: " + ", ".join(words)
+    else:
+        return "You didn't list any valid words to delete!"
+
+
+def request_clear(user: str, bot: Any) -> str:
+    req = bot.db_conn.find_documents(
+        {"users": user},
+        db=bot.db_conn.CONFIG["db"],
+        collection=bot.db_conn.CONFIG["collections"]["book_requests"],
+    )
+
+    for word in req:
+        if user in word["users"]:
+            word["users"].remove(user)
+
+            # Then check to see if the word's list is empty.  If so, remove it from the
+            # collection
+            if len(word["users"]) == 0:
+                bot.db_conn.delete_document(
+                    {"word": word["word"]},
+                    db=bot.db_conn.CONFIG["db"],
+                    collection=bot.db_conn.CONFIG["collections"]["book_requests"]
+                )
+            else:
+                bot.db_conn.update_document_by_oid(
+                    word["_id"],
+                    {"$set": {"users": word["users"]}},
+                    db=bot.db_conn.CONFIG["db"],
+                    collection=bot.db_conn.CONFIG["collections"]["book_requests"]
+                )
+
+    return "All of your requests have been cleared."
+
+
+def request_list(user: str, bot: Any) -> str:
+
+    # We'll us this to store the words that the user has requested
+    personal_list = []
+
+    # Grab a list of requests that include the user
+    req_list = bot.db_conn.find_documents(
+        {"users": user},
+        db=bot.db_conn.CONFIG["db"],
+        collection=bot.db_conn.CONFIG["collections"]["book_requests"],
+    )
+
+    for word in req_list:
+        if user in word["users"]:
+            personal_list.append(word["word"])
+
+    if len(personal_list) > 0:
+        return "Here are your current requests: \n\n{}".format(
+            "\n".join([f"`{x}`" for x in personal_list]))
+    else:
+        return "You haven't made any requests.  Why don't you make one already?!"
+
+
+def request_admin() -> str:
+    return "You have selected the admin option.  Not yet implemented"
+
+
+def request_dump(bot: Any) -> str:
+
+    req_list = bot.db_conn.find_documents(
+        {},
+        db=bot.db_conn.CONFIG["db"],
+        collection=bot.db_conn.CONFIG["collections"]["book_requests"],
+    )
+
+    # Here we are simply iterating through the collection to build a nice
+    # list to print
+
+    return "Here are the current requests:\n\n" + \
+           "\n".join([f"`{req['word']}: {', '.join(req['users'])}`" for req in req_list])
+
+
 def execute(command, user, bot):
     response = None
     attachment = None
-    delay = 10
-    time_attrs = ["hours", "minutes", "seconds"]
-    url = 'https://www.packtpub.com/packt/offers/free-learning/'
 
-    # Split the given command here and set it all to lowercase
-    split_command = separator_regex.findall(command)
+    operation, params = parse_arguments(command)
 
-    # Check to see if the user is trying a request.  If so, insert them
-    # into the collection.  If not, proceed as normal
-    if len(split_command) > 1 and split_command[1] == "request":
-        # If requests are enabled, then do the work.  If not, tell the user that requests are disabled.
-        if bot.db_conn and "book_requests" in bot.db_conn.CONFIG["collections"]:
-            if len(split_command) > 2:
-                # Check to see if the word after "request" is an argument.  If the argument
-                # is something we recognize, then do the appropriate thing.  If not, tell the user
-                # to run the main command for options
+    if operation == "packtbook":
+        delay = 10
+        time_attrs = ["hours", "minutes", "seconds"]
+        url = 'https://www.packtpub.com/packt/offers/free-learning/'
 
-                if split_command[2] in ["-d", "--delete"]:
-                    # Gather the words, making sure there are no blanks
-                    words = [x.lower() for x in split_command[3:] if not x.startswith("-")]
-
-                    # For each word given, remove the user from the word's entry in the collection
-                    if len(words) > 0:
-                        req = bot.db_conn.find_documents(
-                            {"word": {"$in": words}},
-                            db=bot.db_conn.CONFIG["db"],
-                            collection=bot.db_conn.CONFIG["collections"]["book_requests"],
-                        )
-
-                        for word in req:
-                            if user in word["users"]:
-                                word["users"].remove(user)
-
-                                # Then check to see if the word's list is empty.  If so, remove it from the
-                                # collection
-                                if len(word["users"]) == 0:
-                                    bot.db_conn.delete_document(
-                                        {"word": word["word"]},
-                                        db=bot.db_conn.CONFIG["db"],
-                                        collection=bot.db_conn.CONFIG["collections"]["book_requests"]
-                                    )
-                                else:
-                                    bot.db_conn.update_document_by_oid(
-                                        word["_id"],
-                                        {"$set": {"users": word["users"]}},
-                                        db=bot.db_conn.CONFIG["db"],
-                                        collection=bot.db_conn.CONFIG["collections"]["book_requests"]
-                                    )
-
-                        response = "I have deleted your request(s) for: " + ", ".join(words)
-                    else:
-                        # If the words list is empty, then the user didn't provide any valid words
-                        response = "The correct format for deleting requests is the following:\n\n" \
-                            "`@NoobSNHUbot packtbook request -d words, \"or phrases\", to, delete, here`  or:\n" \
-                            "`@NoobSNHUbot packtbook request --delete words, \"or phrases\", to, delete, here`"
-                elif split_command[2] in ["-c", "--clear"]:
-                    req = bot.db_conn.find_documents(
-                        {"users": user},
-                        db=bot.db_conn.CONFIG["db"],
-                        collection=bot.db_conn.CONFIG["collections"]["book_requests"],
-                    )
-
-                    for word in req:
-                        if user in word["users"]:
-                            word["users"].remove(user)
-
-                            # Then check to see if the word's list is empty.  If so, remove it from the
-                            # collection
-                            if len(word["users"]) == 0:
-                                bot.db_conn.delete_document(
-                                    {"word": word["word"]},
-                                    db=bot.db_conn.CONFIG["db"],
-                                    collection=bot.db_conn.CONFIG["collections"]["book_requests"]
-                                )
-                            else:
-                                bot.db_conn.update_document_by_oid(
-                                    word["_id"],
-                                    {"$set": {"users": word["users"]}},
-                                    db=bot.db_conn.CONFIG["db"],
-                                    collection=bot.db_conn.CONFIG["collections"]["book_requests"]
-                                )
-
-                    response = "All of your requests have been cleared."
-                elif split_command[2] in ["-a", "--add"]:
-                    # Gather the words, making sure there are no blanks
-                    words = [x.lower() for x in split_command[2:] if not x.startswith("-")]
-
-                    # See if the words are already in the collection.  If they are, add the user to them if they aren't
-                    # there already.  If the words are not there, add them with an initial list of a single user.
-                    for word in words:
-                        req = bot.db_conn.find_document(
-                            {"word": word},
-                            db=bot.db_conn.CONFIG["db"],
-                            collection=bot.db_conn.CONFIG["collections"]["book_requests"],
-                        )
-
-                        if req:
-                            # Only add the user if they are not in there
-                            if user not in req["users"]:
-                                # Insert the user into the word
-                                req["users"].append(user)
-                                # Then update the document in the db
-                                bot.db_conn.update_document_by_oid(
-                                    req["_id"],
-                                    {"$set": {"users": req["users"]}},
-                                    db=bot.db_conn.CONFIG["db"],
-                                    collection=bot.db_conn.CONFIG["collections"]["book_requests"]
-                                )
-                        else:
-                            bot.db_conn.insert_document(
-                                {"word": word, "users": [user]},
-                                db=bot.db_conn.CONFIG["db"],
-                                collection=bot.db_conn.CONFIG["collections"]["book_requests"],
-                            )
-
-                    if len(words) > 0:
-                        response = "You have made a book request for: " + ", ".join(words)
-                    else:
-                        # If the words list is empty, then the user didn't provide any valid words
-                        response = "The correct format for adding requests is the following:\n\n" \
-                                   "`@NoobSNHUbot packtbook request -a words, \"or phrases\", to, delete, here`  or:\n" \
-                                   "`@NoobSNHUbot packtbook request --add words, \"or phrases\", to, delete, here`"
-                elif split_command[2] in ["-l", "--list"]:
-                    # We'll us this to store the words that the user has requested
-                    personal_list = []
-
-                    # Grab a list of requests that include the user
-                    request_list = bot.db_conn.find_documents(
-                        {"users": user},
-                        db=bot.db_conn.CONFIG["db"],
-                        collection=bot.db_conn.CONFIG["collections"]["book_requests"],
-                    )
-
-                    for word in request_list:
-                        if user in word["users"]:
-                            personal_list.append(word["word"])
-
-                    if len(personal_list) > 0:
-                        response = "Here are your current requests: \n\n{}".format(
-                            "\n".join([f"`{x}`" for x in personal_list]))
-                    else:
-                        response = "You haven't made any requests.  Why don't you make one already?!"
-                elif split_command[2] == "--justforfun":
-                    request_list = bot.db_conn.find_documents(
-                        {},
-                        db=bot.db_conn.CONFIG["db"],
-                        collection=bot.db_conn.CONFIG["collections"]["book_requests"],
-                    )
-
-                    # Here we are simply iterating through the collection to build a nice
-                    # list to print
-
-                    response = "Here are the current requests:\n\n" + \
-                               "\n".join([f"`{req['word']}: {', '.join(req['users'])}`" for req in request_list])
-                elif split_command[2] == "--admin":
-                    response = "You have selected the admin option.  Not yet implemented."
-                else:
-                    response = "Unknown symbol or argument detected. Run `@NoobSNHUbot packtbook request` " \
-                               "for a list of options."
-            else:
-                response = "The correct format is the following:\n\n" \
-                    "*To see your requests:*\n`@NoobSNHUbot packtbook request -l`  or:\n" \
-                    "`@NoobSNHUbot packtbook request --list`\n" \
-                    "*To add:*\n`@NoobSNHUbot packtbook request -a words, \"or phrases\", to, add, here`  or:\n" \
-                    "`@NoobSNHUbot packtbook request --add words, \"or phrases\", to, add, here`\n" \
-                    "*To delete:*\n`@NoobSNHUbot packtbook request -d words, \"or phrases\", to, delete, here`  or:\n" \
-                    "`@NoobSNHUbot packtbook request --delete words, \"or phrases\", to, delete, here`\n" \
-                    "*To clear all*:\n`@NoobSNHUbot packtbook request -c`  or:\n" \
-                    "`@NoobSNHUbot packtbook request --clear`"
-
-        else:
-            response = "Requests are currently disabled.  Contact your workspace admin for information."
-    else:
         # Simple catch all error logic
         try:
             # Set the driver to wait a little bit before assuming elements are not present, then grab the page:
@@ -288,10 +299,11 @@ def execute(command, user, bot):
                     time_format = "{}, {}, and {}"
 
                 time_left_string = time_format.format(*times_left)
+                flavor_text = f"{', '.join([f'<@{x}>' for x in tag_list])}" if len(tag_list) > 0 else ""
 
                 output = {
                     "pretext": f"The Packt Free Book of the Day is:",
-                    "text": f"Come and get it!\n{', '.join([f'<@{x}>' for x in tag_list])}",
+                    "text": flavor_text,
                     "title": book_string,
                     "title_link": url,
                     "footer": "There's still {} to get this book!".format(time_left_string),
@@ -314,5 +326,36 @@ def execute(command, user, bot):
 
             response = 'I have failed my human overlords!\nYou should be able to find the Packt Free' \
                        ' Book of the day here: {}'.format(url)
+        return response, attachment
+    elif operation == "packtbook_help":
+        response = "The correct format is the following:\n\n" \
+            "*To see today's book:*\n`@NoobSNHUbot packtbook`\n" \
+            "*To see your requests:*\n`@NoobSNHUbot packtbook request -l`  or:\n" \
+            "`@NoobSNHUbot packtbook request --list`\n" \
+            "*To add requests:*\n`@NoobSNHUbot packtbook request -a words, \"or phrases\", to, add`  or:\n" \
+            "`@NoobSNHUbot packtbook request --add words, \"or phrases\", to, add`\n" \
+            "*To delete requests:*\n`@NoobSNHUbot packtbook request -d words, \"or phrases\", to, delete`  or:\n" \
+            "`@NoobSNHUbot packtbook request --delete words, \"or phrases\", to, delete`\n" \
+            "*To clear all requests*:\n`@NoobSNHUbot packtbook request -c`  or:\n" \
+            "`@NoobSNHUbot packtbook request --clear`"
+    else:
+        if bot.db_conn and "book_requests" in bot.db_conn.CONFIG["collections"]:
+            if operation == "request_add":
+                response = request_add(params, user, bot)
+            elif operation == "request_delete":
+                response = request_delete(params, user, bot)
+            elif operation == "request_clear":
+                response = request_clear(user, bot)
+            elif operation == "request_list":
+                response = request_list(user, bot)
+            elif operation == "request_admin":
+                response = request_admin()
+            elif operation == "request_dump":
+                response = request_dump(bot)
+            else:
+                response = "Sorry, I don't recognize the Packtbook option you entered. " \
+                           " Were you trying to make a request?"
+        else:
+            response = "Request functions are currently disabled.  Contact the workspace admin for information."
 
     return response, attachment

--- a/cmds/xkcd.py
+++ b/cmds/xkcd.py
@@ -1,0 +1,37 @@
+import json
+import requests
+
+command = "xkcd"
+public = True
+
+"""	
+month	"10"
+num	2217
+link	""
+year	"2019"
+news	""
+safe_title	"53 Cards"
+transcript	""
+alt	"Well, there's one right here at the bottom, where it says \"53.\""
+img	"https://imgs.xkcd.com/comics/53_cards.png"
+title	"53 Cards"
+day	"18"
+"""
+
+def execute(command, user, bot):
+    attachment = None
+    response = None
+
+    r = requests.get('https://xkcd.com/info.0.json')
+
+    if r.status_code == 200:
+        data = json.loads(r.text)
+
+        attachment = json.dumps([{
+            "title": "{}".format(data["title"]),
+            "title_link": "https://xkcd.com/{}".format(data["num"]),
+            "image_url": "{}".format(data["img"]),
+            "footer": "{}".format(data["alt"])
+        }])
+
+    return response, attachment

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@ with `@Noob SNHUbot`:
     * Enabled by adding a `book_requests` section to the mongo configuration as seen below.  Requests can be disabled independently of mongo by simply omitting `book_requests`.
     * `@Noob SNHUbot packtbook request (-a/--add) [list, of, words, "or phrases", here]` adds request words for the requesting user.
     * `@Noob SNHUbot packtbook request (-d/--delete) [list, of, words, "or phrases", here]` deletes the given word(s) from the user's requests.
+    * `@Noob SNHUbot packtbook request (-l/--list)` returns a list of the user's current requests.
     * `@Noob SNHUbot packtbook request (-c/--clear)` clears all of the user's requests.
     * `@Noob SNHUbot packtbook request --justforfun` prints out an ugly list of all of the current requests.
     * `@Noob SNHUbot packtbook request --admin` is intended for admin functionality, but is not yet implemented.

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ with `@Noob SNHUbot`:
     * `@Noob SNHUbot packtbook request (-d/--delete) [list, of, words, "or phrases", here]` deletes the given word(s) from the user's requests.
     * `@Noob SNHUbot packtbook request (-l/--list)` returns a list of the user's current requests.
     * `@Noob SNHUbot packtbook request (-c/--clear)` clears all of the user's requests.
-    * `@Noob SNHUbot packtbook request --justforfun` prints out an ugly list of all of the current requests.
+    * `@Noob SNHUbot packtbook request --dump` prints out an ugly list of all of the current requests.
     * `@Noob SNHUbot packtbook request --admin` is intended for admin functionality, but is not yet implemented.
     * Words can be separated either by space or comma.  Phrases need to be enclosed by quotes `""`.
   * If requests are enabled in the configuration, users are tagged when books are posted if words in the book's title match a user's request words.

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,8 @@ with `@Noob SNHUbot`:
 * what's my name?
   * Simple call and response.
   * Responds with: _"Your name is `<@{name}>`! Did you forget or something?"_
+* xkcd
+  * Pulls the latest version of the xkcd comic as a Slack attachment
 
 ## Modular Commands
 

--- a/tests/unit/cmds/test_cmd_xkcd.py
+++ b/tests/unit/cmds/test_cmd_xkcd.py
@@ -1,0 +1,36 @@
+import json
+import string
+import random
+
+from Bot import Bot
+
+from cmds import xkcd as cmd_xkcd
+
+
+class TestCmdXkcd(object):
+
+
+    cmd = "xkcd"
+
+    uid = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                  for _ in range(9))
+    bot = Bot(uid, None, None)
+
+    def test_command(self):
+        assert cmd_xkcd.command == self.cmd
+
+    def test_public(self):
+        assert cmd_xkcd.public
+
+    def test_output_types(self):
+        response = cmd_xkcd.execute(self.cmd, self.uid, self.bot)
+
+        assert isinstance(response, tuple)
+        assert response[0] is None
+        assert isinstance(response[1], str)
+
+    def test_output(self):
+        response = cmd_xkcd.execute(self.cmd, self.uid, self.bot)
+
+        data = json.loads(response[1])
+        assert data is not None


### PR DESCRIPTION
1. Users can now view their own book requests via `@Noob_SNHUbot packtbook request --list`.
2. Code was refactored so at the very least it's easier to find stuff.
3. The command now either accepts "request" or "requests".
4. The `--justforfun` addition was renamed to `--dump`.
4. The message "Come get it!" felt weird and was removed.
5. The help message pops up whenever something wasn't entered correctly.

I have no idea why the xkcd files are showing as changed.  I'm guessing it's a mix up in commit orders from my rebase.